### PR TITLE
feat: add components and styles to display empty Sudoku board

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,36 @@ import GameBoard from './components/GameBoard.vue'
   <main>
     <GameBoard />
   </main>
+  <aside>
+    <header><h1>Sudoku</h1></header>
+  </aside>
 </template>
 
-<style scoped></style>
+<style scoped>
+main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  height: calc(100vw - 4rem);
+  max-height: calc(100vh - 4rem);
+}
+
+aside {
+  width: 100%;
+  padding: 2rem 0;
+}
+
+@media (min-width: 969px) {
+  aside {
+    min-width: 300px;
+    padding: 0 2rem;
+  }
+
+  main {
+    display: flex;
+    place-items: flex-start;
+    width: 100%;
+  }
+}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,11 +31,5 @@ aside {
     min-width: 300px;
     padding: 0 2rem;
   }
-
-  main {
-    display: flex;
-    place-items: flex-start;
-    width: 100%;
-  }
 }
 </style>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -4,5 +4,13 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
+  height: 100vh;
   font-weight: normal;
+}
+
+@media (min-width: 969px) {
+  #app {
+    display: flex;
+    flex-direction: row;
+  }
 }

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -8,4 +8,12 @@ import SudokuBlock from './SudokuBlock.vue'
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.board {
+  display: grid;
+  width: calc(100vmin - 4rem);
+  height: calc(100vmin - 4rem);
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+}
+</style>

--- a/src/components/NumberBlock.vue
+++ b/src/components/NumberBlock.vue
@@ -5,9 +5,15 @@
 </template>
 
 <style scoped>
+/** 
+ * Even though styles are scoped, the class name here must be different than parent,
+ * as class from parent would otherwise override styles.
+ * This only goes one level from parent to child and only applies to the child's root element.
+ **/
 .number-block {
   border: 1px solid darkgray;
-  width: 24px;
-  height: 24px;
+  width: 100%;
+  height: 100%;
 }
 </style>
+`

--- a/src/components/SudokuBlock.vue
+++ b/src/components/SudokuBlock.vue
@@ -11,5 +11,9 @@ import NumberBlock from './NumberBlock.vue'
 <style scoped>
 .sudoku-block {
   border: 1px solid black;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
- Add styles for each component to build board visually
- Make board responsive to always match the smaller dimension between viewport height/width